### PR TITLE
Https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ $ npm install
 ```
 Will install all dependencies (build and runtime dependencies)
 ## Configuration
+### Server
+Create a config.json file that can be passed as cmd arg
+```javascript
+{
+  "port": 80,
+  "https": {
+    "port": 443,
+    "certificate": "[cert]",
+    "key": "[key]",
+    "passphrase": "[passphase]" // optional
+  }
+}
+```
+If you don't specify the https property. The server will run without HTTPS-Encryption
+### Client
 Change the config.js in server/asset/config.js to use your servers.
 ```javascript
 socket: {
@@ -31,9 +46,9 @@ turn: [] // array of turn configurations
 ```
 ## Run
 ```
-$ npm start
+$ npm start [config file]
 ```
-Will run the server
+Will run the server. The config file is the configuration for the server
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Will install all dependencies (build and runtime dependencies)
 Create a config.json file that can be passed as cmd arg
 ```javascript
 {
-  "port": 80,
+  "port": [http port],
   "https": {
-    "port": 443,
+    "port": [https port],
     "certificate": "[cert]",
     "key": "[key]",
     "passphrase": "[passphase]" // optional

--- a/server/asset/components/main/Main.js
+++ b/server/asset/components/main/Main.js
@@ -23,8 +23,7 @@ export default class Main extends React.Component {
       joinData: null,
       user: {}
     };
-    let socketURL = 'ws://' + config.socket.host + ':' + config.socket.port;
-    this._socket = new ClientSocket(socketURL, () => {
+    this._socket = new ClientSocket(config.socket.host, config.socket.port, () => {
       this._socket.send({
         type: message_types.REGISTER,
         username: window.username

--- a/server/asset/lib/ClientSocket.js
+++ b/server/asset/lib/ClientSocket.js
@@ -1,15 +1,20 @@
 'use strict';
 export default class ClientSocket {
-  constructor(url, connected, disconnected) {
+  constructor(host, port, connected, disconnected) {
     this._messageHandlers = {};
     this._connectedCallback = connected;
     this._disconnectedCallback = disconnected;
-    this._socket = new WebSocket(url);
+    let socketURL = (this._isTLS ? 'wss' : 'ws') + '://' + host + ':' + port;
+    this._socket = new WebSocket(socketURL);
     this._socket.onopen = connected;
     this._socket.onclose = disconnected;
     this._socket.onmessage = this._handleMessage.bind(this);
   }
   
+  _isTLS() {
+    return (window.location.protocol === 'https:')
+  }
+
   _connected() {
     console.log('Connected');
     if (this._connectedCallback) {

--- a/server/run.js
+++ b/server/run.js
@@ -11,15 +11,19 @@ function validateConfig(config) {
   return retVal;
 }
 
+function launch(config) {
+  if (validateConfig(config)) {
+    new Server(config);
+  } else {
+    console.log('INVALID CONFIG\nEXIT');
+  }
+}
+
 console.log('\n-------------------------------------------------');
 console.log('  ' + pkg.name);
 console.log('    v' + pkg.version);
 console.log('-------------------------------------------------\n');
-
-let config = {
-  port: 80
-};
-
+let config;
 if (process.argv[2]) {
   let configFile = fs.readFileSync(process.argv[2]);
   if (configFile) {
@@ -27,8 +31,8 @@ if (process.argv[2]) {
   }
 }
 
-if (validateConfig(config)) {
-  new Server(config);
+if (config) {
+  launch(config);
 } else {
-  console.log('INVALID CONFIG\nEXIT');
+  console.log('Please, specify a config file');
 }


### PR DESCRIPTION
Enable HTTPS support for pitch it server.
The feature will be enabled using the server config and the new https property
It will create an HTTPS endpoint for web requests and upgrade all incoming http requests automatically to HTTPS.
Also the websocket will be upgraded to HTTPS.
For the server config a new property was included:
```javascript
{
  ...
  "https": {
    "port": [port],
    "certificate": "[cert]",
    "key": "[key]",
    "passphrase": "passphrase" // optional
  }
  ...
}
```
Also a config for the server is now required to be passed via command line arguments.